### PR TITLE
US988009: fix in app warning when running the SDK on Android with rea…

### DIFF
--- a/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/AccessCheckoutReactNativeModule.kt
+++ b/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/AccessCheckoutReactNativeModule.kt
@@ -133,6 +133,25 @@ class AccessCheckoutReactNativeModule constructor(
         }
     }
 
+
+    /**
+     * Required to prevent a warning from being displayed when running react-native >= 0.65
+     */
+    @Suppress("UNUSED_PARAMETER", "unused")
+    @ReactMethod
+    fun addListener(eventName: String?) {
+
+    }
+
+    /**
+     * Required to prevent a warning from being displayed when running react-native >= 0.65
+     */
+    @Suppress("UNUSED_PARAMETER", "unused")
+    @ReactMethod
+    fun removeListeners(count: Double) {
+
+    }
+
     override fun onCatalystInstanceDestroy() {
         if (accessCheckoutClient != null) {
             accessCheckoutClientDisposer.dispose(accessCheckoutClient!!)

--- a/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/AccessCheckoutReactNativeModuleUnitTest.kt
+++ b/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/AccessCheckoutReactNativeModuleUnitTest.kt
@@ -1,0 +1,25 @@
+package com.worldpay.access.checkout.reactnative
+
+import com.facebook.react.bridge.ReactMethod
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class AccessCheckoutReactNativeModuleUnitTest {
+    @Test
+    fun `module has a React method called addListener() with one String parameter`() {
+        val method = AccessCheckoutReactNativeModule::class.java
+            .getMethod("addListener", String::class.java)
+
+        assertThat(method).isNotNull
+        assertThat(method.getAnnotation(ReactMethod::class.java)).isNotNull
+    }
+
+    @Test
+    fun `module has a React method called removeListeners() with one Double parameter`() {
+        val method = AccessCheckoutReactNativeModule::class.java
+            .getMethod("removeListeners", Double::class.java)
+
+        assertThat(method).isNotNull
+        assertThat(method.getAnnotation(ReactMethod::class.java)).isNotNull
+    }
+}


### PR DESCRIPTION
…ct-native >= 0.65

Warnings displayed were
- `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
- `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.