### PR TITLE
Us1410844: add a step in BitRise build to list dependencies that have been installed by NPM

### DIFF
--- a/demo-app/bitrise.yml
+++ b/demo-app/bitrise.yml
@@ -19,6 +19,11 @@ workflows:
         inputs:
         - command: install
         - workdir: $BITRISE_SOURCE_DIR/demo-app/
+    - npm@1:
+        title: "Listing demo-app dependencies that have been installed"
+        inputs:
+          - command: ls
+          - workdir: $BITRISE_SOURCE_DIR/demo-app/
     - script@1.2:
         title: "Build app for Detox"
         inputs:
@@ -65,6 +70,11 @@ workflows:
         inputs:
         - command: install
         - workdir: $BITRISE_SOURCE_DIR/demo-app/
+    - npm@1:
+        title: "Listing demo-app dependencies that have been installed"
+        inputs:
+          - command: ls
+          - workdir: $BITRISE_SOURCE_DIR/demo-app/
     - cocoapods-install@2:
         title: "Install pods for iOS Bridge SDK"
         inputs:


### PR DESCRIPTION
This is for debugging purposes for cases where we have issues with Detox and to check which version of Detox is installed by NPM