### PR TITLE
Us1525126 add CHANGELOG.md to published archive

### DIFF
--- a/access-checkout-react-native-sdk/package.json
+++ b/access-checkout-react-native-sdk/package.json
@@ -27,7 +27,8 @@
     "android/com",
     "ios/AccessCheckoutReactNative",
     "ios/AccessCheckoutReactNativeSDKiOSBridge.podspec",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "README.md"
   ],
   "devDependencies": {
     "@babel/core": "^7.16.5",


### PR DESCRIPTION
## What
- add CHANGELOG.MD in the list of files published to NPM
- also added README.MD but this one is published by default anyway. Added it to make it obvious that it's published as well

## Why
- the CHANGELOG would not get published otherwise. It's a useful file so it needs to be published