### PR TITLE
Fix issue in Blackduck pipeline where the Android Bridge version is empty

### DIFF
--- a/access-checkout-react-native-sdk/ios/bitrise.yml
+++ b/access-checkout-react-native-sdk/ios/bitrise.yml
@@ -38,6 +38,3 @@ workflows:
         - deploy_path: "${BITRISE_SOURCE_DIR}/coverage.html"
     - cache-push@2: {}
     envs: []
-meta:
-  bitrise.io:
-    stack: osx-xcode-13.0.x

--- a/access-checkout-react-native-sdk/ios/bitrise.yml
+++ b/access-checkout-react-native-sdk/ios/bitrise.yml
@@ -20,6 +20,7 @@ workflows:
     - xcode-test@4:
         inputs:
         - scheme: AccessCheckoutReactNative
+        - destination: "platform=iOS Simulator,name=iPhone 12 Pro,OS=latest"
         - project_path: "$BITRISE_SOURCE_DIR/access-checkout-react-native-sdk/ios/AccessCheckoutReactNative.xcworkspace"
         - generate_code_coverage_files: "yes"
     - xctest-html-report@1:

--- a/demo-app/.detoxrc.json
+++ b/demo-app/.detoxrc.json
@@ -14,7 +14,7 @@
     "ios": {
       "type": "ios.app",
       "binaryPath": "ios/Build/Build/Products/Debug-iphonesimulator/AccessCheckoutReactNativeDemo.app",
-      "build": "./scripts/ios-detox-build.sh -v=15.0"
+      "build": "./scripts/ios-detox-build.sh -v=15"
     },
     "android": {
       "type": "android.apk",
@@ -33,7 +33,7 @@
     "ios-ci": {
       "type": "ios.simulator",
       "device": {
-        "os": "iOS 15.0",
+        "os": "iOS 15.5",
         "type": "iPad (9th generation)"
       }
     },

--- a/demo-app/scripts/ios-find-simulator.sh
+++ b/demo-app/scripts/ios-find-simulator.sh
@@ -47,6 +47,9 @@ else
   # escapes the . character with a \ if it is present in the version string
   if [[ "$version" == *"."* ]]; then
     grepPattern="${version//./\.}"
+  # otherwise enrich regex pattern to find a simulator that has a minor version as well
+  else
+    grepPattern="${version}\.\d"
   fi
 
   simulator=$(cat $filename | grep -m 1 "${grepPattern}")

--- a/demo-app/src/card-flow/CardFlow.tsx
+++ b/demo-app/src/card-flow/CardFlow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Text } from 'react-native';
+import { Text } from 'react-native';
 import {
   AccessCheckout,
   Brand,
@@ -13,6 +13,7 @@ import {
 } from '../../../access-checkout-react-native-sdk/src/index';
 import CardBrandImage from '../common/CardBrandImage';
 import CvcField from '../common/CvcField';
+import ErrorView from '../common/ErrorView';
 import ExpiryDateField from '../common/ExpiryDateField';
 import HView from '../common/HView';
 import PanField from '../common/PanField';
@@ -50,6 +51,8 @@ export default function CardFlow() {
 
   const [cardSession, setCardSession] = useState('');
   const [cvcSession, setCvcSession] = useState('');
+
+  const [error, setError] = useState<Error>();
 
   const accessCheckout = new AccessCheckout({
     baseUrl: 'https://npe.access.worldpay.com',
@@ -108,7 +111,7 @@ export default function CardFlow() {
   const { initialiseCardValidation } = useCardValidation(
     accessCheckout,
     validationConfig,
-    validationEventListener
+    validationEventListener,
   );
 
   const onLayout = () => {
@@ -116,8 +119,8 @@ export default function CardFlow() {
       .then(() => {
         console.info('Card Validation successfully initialised');
       })
-      .catch((error) => {
-        Alert.alert('Error', `${error}`, [{ text: 'OK' }]);
+      .catch((e) => {
+        setError(e);
       });
   };
 
@@ -146,8 +149,8 @@ export default function CardFlow() {
           setCvcSession(sessions.cvc);
         }
       })
-      .catch((reason) => {
-        Alert.alert('Error', `${reason}`, [{ text: 'OK' }]);
+      .catch((e) => {
+        setError(e);
       })
       .finally(() => {
         setShowSpinner(false);
@@ -158,6 +161,7 @@ export default function CardFlow() {
 
   let cardSessionComponent;
   let cvcSessionComponent;
+  let errorComponent;
 
   if (cardSession) {
     cardSessionComponent = (
@@ -179,9 +183,14 @@ export default function CardFlow() {
     );
   }
 
+  if (error) {
+    errorComponent = <ErrorView error={error} />;
+  }
+
   return (
     <VView style={styles.cardFlow} onLayout={onLayout}>
       <Spinner testID="spinner" show={showSpinner} />
+      {errorComponent}
       <HView>
         <PanField
           testID="panInput"

--- a/demo-app/src/common/ErrorView.tsx
+++ b/demo-app/src/common/ErrorView.tsx
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import { StyleSheet, Text } from 'react-native';
+import HView from './HView';
+
+interface ErrorProps {
+  error: Error;
+}
+
+const styles = StyleSheet.create({
+  view: {
+    flexDirection: 'row',
+    marginTop: '2%',
+    marginRight: '2%',
+  },
+  prefix: {
+    fontSize: 11,
+    color: 'red',
+    fontWeight: 'bold',
+    marginRight: 5,
+  },
+  text: {
+    fontSize: 11,
+    color: 'red',
+  },
+});
+
+export default class ErrorView extends Component<ErrorProps> {
+  constructor(props: ErrorProps) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <HView style={styles.view}>
+        <Text style={styles.prefix}>Error:</Text>
+        <Text style={styles.text}>{this.props.error.message}</Text>
+      </HView>
+    );
+  }
+}

--- a/demo-app/src/cvc-flow/CvcFlow.tsx
+++ b/demo-app/src/cvc-flow/CvcFlow.tsx
@@ -16,9 +16,10 @@ import VView from '../common/VView';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import styles from '../card-flow/style.js';
-import { Alert, Text } from 'react-native';
+import { Text } from 'react-native';
 import SessionLabel from '../common/SessionLabel';
 import CvcOnlyFlowE2eStates from '../cvc-flow/CvcOnlyFlow.e2e.states';
+import ErrorView from '../common/ErrorView';
 
 export default function CvcFlow() {
   const [cvcValue, setCvc] = useState<string>('');
@@ -30,6 +31,8 @@ export default function CvcFlow() {
 
   const [cvcSession, setCvcSession] = useState('');
 
+  const [error, setError] = useState<Error>();
+  
   const accessCheckout = new AccessCheckout({
     baseUrl: 'https://npe.access.worldpay.com',
     merchantId: 'identity',
@@ -63,8 +66,8 @@ export default function CvcFlow() {
       .then(() => {
         console.info('Cvc Only Validation successfully initialised');
       })
-      .catch((error) => {
-        Alert.alert('Error', `${error}`, [{ text: 'OK' }]);
+      .catch((e) => {
+        setError(e);
       });
   };
 
@@ -81,14 +84,14 @@ export default function CvcFlow() {
     accessCheckout
       .generateSessions(cardDetails, sessionTypes)
       .then((sessions: Sessions) => {
-        console.info(`Successfully generated session(s)`);
+        console.info('Successfully generated session(s)');
 
         if (sessions.cvc) {
           setCvcSession(sessions.cvc);
         }
       })
-      .catch((reason) => {
-        Alert.alert('Error', `${reason}`, [{ text: 'OK' }]);
+      .catch((e) => {
+        setError(e);
       })
       .finally(() => {
         setShowSpinner(false);
@@ -98,6 +101,7 @@ export default function CvcFlow() {
   }
 
   let cvcSessionComponent;
+  let errorComponent;
 
   if (cvcSession) {
     cvcSessionComponent = (
@@ -109,11 +113,16 @@ export default function CvcFlow() {
     );
   }
 
+  if (error) {
+    errorComponent = <ErrorView error={error} />;
+  }
+  
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return (
     <VView style={styles.cardFlow} onLayout={onLayout}>
       <Spinner testID="spinner" show={showSpinner} />
+      {errorComponent}
       <HView>
         <CvcField
           testID="cvcInput"

--- a/scripts/blackduck/run_scan.sh
+++ b/scripts/blackduck/run_scan.sh
@@ -3,9 +3,27 @@
 echo "Initiating Blackduck Scan..."
 cd access-checkout-react-native-sdk
 SDK_VERSION=$(sed -e 's/^"//' -e 's/"$//' <<< $(jq '.version' package.json))
-ANDROID_BRIDGE_VERSION=$(cat android/gradle.properties | grep -m 1 'version=' | sed 's/version=//')
+ANDROID_BRIDGE_VERSION=$(cat android/access-checkout-react-native-sdk-android-bridge/gradle.properties | grep -m 1 'version=' | sed 's/version=//')
 ANDROID_BRIDGE_GRADLE_CONFIGURATIONS_TO_SCAN="mainReleaseCompileClasspath,mainReleaseRuntimeClasspath"
 IOS_BRIDGE_VERSION=$(cat ios/AccessCheckoutReactNativeSDKiOSBridge.podspec | grep -m 1 's.version' | sed -e 's/\ //g' -e 's/s\.version=//' -e 's/\"//g')
+
+if [ -z "${SDK_VERSION}" ]
+then
+    echo "Cannot proceed, SDK version is empty"
+    exit 1
+fi
+
+if [ -z "${ANDROID_BRIDGE_VERSION}" ]
+then
+    echo "Cannot proceed, Android Bridge version is empty"
+    exit 1
+fi
+
+if [ -z "${IOS_BRIDGE_VERSION}" ]
+then
+    echo "Cannot proceed, iOS Bridge version is empty"
+    exit 1
+fi
 
 # This environment variable is used by the detect script to download a fixed version
 export DETECT_LATEST_RELEASE_VERSION=$BLACKDUCK_DETECT_VERSION


### PR DESCRIPTION
## What
- fix issue in Blackduck pipeline where the Android Bridge version is empty. This issue has been caused by the fact that the files for the Android bridge have been moved into a new subfolder
- fix issue in script used to search for iOS simulators so it supports just a major iOS version, rather than requiring major.minor
- change app to display error in div rather than in Alert

## How
-  In the blackduck scan script, the path to the Android bridge file that contains the version has been changed to point to the the correct path. A few `ifs` have been added to ensure the Blackduck scan fails in the future if any of the SDK, iOS bridge, Android Bridge versions are empty
- Errors are now displayed using a new ErrorView component

## Why
- this issue causes the Android bridge version in Blackduck to be registered as empty
- displaying error in div rather than alerts contributes to diminish issues when running Android e2e tests
- bug in ios find simulator script used to fail the setup of the iOS e2e tests

 