### PR TITLE
NOTICKET: fix Blackduck job issues

### DIFF
--- a/access-checkout-react-native-sdk/android/access-checkout-react-native-sdk-android-bridge/build.gradle
+++ b/access-checkout-react-native-sdk/android/access-checkout-react-native-sdk-android-bridge/build.gradle
@@ -39,7 +39,7 @@ apply from: './gradle/jacoco.gradle'
 apply from: './gradle/publications.gradle'
 
 dependencies {
-    api 'com.facebook.react:react-native:0.+'
+    implementation 'com.facebook.react:react-native:0.+'
 
     implementation 'com.worldpay.access:access-checkout-android:3.0.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'

--- a/buildspec_blackduck.yml
+++ b/buildspec_blackduck.yml
@@ -4,6 +4,12 @@ env:
   secrets-manager:
     hydra_aco_blackduck_token: hydra_aco_blackduck:hydra_aco_blackduck_token
 phases:
+  install:
+    runtime-versions:
+      nodejs: 12
+  pre_build:
+    commands:
+      - cd access-checkout-react-native-sdk && npm install && cd ..
   build:
     commands:
       - ./scripts/blackduck/run_scan.sh

--- a/scripts/blackduck/run_scan.sh
+++ b/scripts/blackduck/run_scan.sh
@@ -4,7 +4,7 @@ echo "Initiating Blackduck Scan..."
 cd access-checkout-react-native-sdk
 SDK_VERSION=$(sed -e 's/^"//' -e 's/"$//' <<< $(jq '.version' package.json))
 ANDROID_BRIDGE_VERSION=$(cat android/access-checkout-react-native-sdk-android-bridge/gradle.properties | grep -m 1 'version=' | sed 's/version=//')
-ANDROID_BRIDGE_GRADLE_CONFIGURATIONS_TO_SCAN="mainReleaseCompileClasspath,mainReleaseRuntimeClasspath"
+ANDROID_BRIDGE_GRADLE_CONFIGURATIONS_TO_SCAN="coreReleaseCompileClasspath,coreReleaseRuntimeClasspath"
 IOS_BRIDGE_VERSION=$(cat ios/AccessCheckoutReactNativeSDKiOSBridge.podspec | grep -m 1 's.version' | sed -e 's/\ //g' -e 's/s\.version=//' -e 's/\"//g')
 
 if [ -z "${SDK_VERSION}" ]
@@ -40,5 +40,22 @@ then
 fi
 
 ./detect.sh --blackduck.url="https://fis2.app.blackduck.com/" --blackduck.api.token=$hydra_aco_blackduck_token --blackduck.trust.cert=true --detect.project.name=$BLACKDUCK_PROJECT_NAME_RN --detect.project.version.name=$SDK_VERSION --detect.risk.report.pdf=true --detect.npm.include.dev.dependencies=false --detect.excluded.directories=android,ios
-./detect.sh --blackduck.url="https://fis2.app.blackduck.com/" --blackduck.api.token=$hydra_aco_blackduck_token --blackduck.trust.cert=true --detect.project.name=$BLACKDUCK_PROJECT_NAME_ANDROID_BRIDGE --detect.project.version.name=$ANDROID_BRIDGE_VERSION --detect.risk.report.pdf=true --detect.source.path=android --detect.gradle.included.configurations="$ANDROID_BRIDGE_GRADLE_CONFIGURATIONS_TO_SCAN"
-./detect.sh --blackduck.url="https://fis2.app.blackduck.com/" --blackduck.api.token=$hydra_aco_blackduck_token --blackduck.trust.cert=true --detect.project.name=$BLACKDUCK_PROJECT_NAME_IOS_BRIDGE --detect.project.version.name=$IOS_BRIDGE_VERSION --detect.risk.report.pdf=true --detect.source.path=ios
+if [ $? -ne 0 ] ; then
+  echo "Failed scan for TypeScript SDK. Exiting"
+  exit 1
+fi
+
+# Android SDK
+cd android
+../detect.sh --blackduck.url="https://fis2.app.blackduck.com/" --blackduck.api.token=$hydra_aco_blackduck_token --blackduck.trust.cert=true --detect.project.name=$BLACKDUCK_PROJECT_NAME_ANDROID_BRIDGE --detect.project.version.name=$ANDROID_BRIDGE_VERSION --detect.risk.report.pdf=true --detect.gradle.included.configurations="$ANDROID_BRIDGE_GRADLE_CONFIGURATIONS_TO_SCAN"
+if [ $? -ne 0 ] ; then
+  echo "Failed scan for Android bridge. Exiting"
+  exit 1
+fi
+
+cd ../ios
+../detect.sh --blackduck.url="https://fis2.app.blackduck.com/" --blackduck.api.token=$hydra_aco_blackduck_token --blackduck.trust.cert=true --detect.project.name=$BLACKDUCK_PROJECT_NAME_IOS_BRIDGE --detect.project.version.name=$IOS_BRIDGE_VERSION --detect.risk.report.pdf=true
+if [ $? -ne 0 ] ; then
+  echo "Failed scan for iOS bridge. Exiting"
+  exit 1
+fi

--- a/scripts/blackduck/run_scan.sh
+++ b/scripts/blackduck/run_scan.sh
@@ -4,7 +4,7 @@ echo "Initiating Blackduck Scan..."
 cd access-checkout-react-native-sdk
 SDK_VERSION=$(sed -e 's/^"//' -e 's/"$//' <<< $(jq '.version' package.json))
 ANDROID_BRIDGE_VERSION=$(cat android/access-checkout-react-native-sdk-android-bridge/gradle.properties | grep -m 1 'version=' | sed 's/version=//')
-ANDROID_BRIDGE_GRADLE_CONFIGURATIONS_TO_SCAN="coreReleaseCompileClasspath,coreReleaseRuntimeClasspath"
+ANDROID_BRIDGE_GRADLE_CONFIGURATIONS_TO_SCAN="coreReleaseRuntimeClasspath"
 IOS_BRIDGE_VERSION=$(cat ios/AccessCheckoutReactNativeSDKiOSBridge.podspec | grep -m 1 's.version' | sed -e 's/\ //g' -e 's/s\.version=//' -e 's/\"//g')
 
 if [ -z "${SDK_VERSION}" ]


### PR DESCRIPTION
## What
1. Blackduck job used to complete successfully despite some of the Blackduck scans failing
2. Fix issue causing the Android Blackduck scan producing empty inventories
3. Before running the Blackduck scan for Android and iOS we cd into the `android` and `ios` directories to avoid having to pass the source path option to the Blackduck binary

## How
1. The Blackduck scan commands exit code were not checked hence why the script was carrying on despite some commands failing and eventually completing successfully. Statements to check exit codes have been added and will exit 1 in case of failures
2. Few root causes have been identified and fixed
  - the buildspec has been changed to install NPM dependencies ahead of running scans because a react native plugin is required for the Gradle config to work
  - this issue was due to the fact that Android Gradle configurations names (i.e. artifacts configurations names) had changed following to the React Native migration to 0.70.0 but these config names had not been updated in the Blackduck scan, hence the old config specified could not be found and Blackduck would produce an empty inventory