### PR TITLE
US1764780 - Amend README's to be in line with Checkout Implementation and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## React & React Native Compatibility
 
-Our SDK is compatible with `React 16.13.1` and `React Native 0.63.4`
+Find the versions compatible with our SDK in the [package.json](access-checkout-react-native-sdk/package.json).
 
 ## Getting Started
 

--- a/access-checkout-react-native-sdk/README.md
+++ b/access-checkout-react-native-sdk/README.md
@@ -19,6 +19,15 @@ You can find the detailed documentation explaining how to integrate the SDK and 
 - all `react` versions >= `16.9.0`
 - `Cocoapods` only for iOS dependencies
 
+## SAQ-A Compliance
+
+AccessCheckoutTextInput is the name of the new component created to provide SAQ-A compliance when using our React Native SDK.
+It has been designed so that it does not expose any methods or properties to retrieve the text entered by the end user to ensure our merchants meet SAQ-A compliancy.
+
+## AccessCheckoutTextInput
+
+You can find detailed documentation explaining about our new component [AccessCheckoutTextInput](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native/access-checkout-text-input) within the [React Native section](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native) of the [Access Worldpay documentation](https://developer.worldpay.com).
+
 ## How to install
 
 Refer to [Get our SDK](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native#get-our-sdk) in the React Native section of the [Access Worldpay documentation](https://developer.worldpay.com)


### PR DESCRIPTION
### **WHAT**

I want to read information in the README's of the React Native SDK Repository which is inline with Checkout implementation and functionality 

### **HOW**

- README at the base of the repo contains the link to the package.json file and explains the current supported versions of React and React Native 
- README under the access-checkout-react-native-sdk folder contains details about the SAQ-A compliance feature of the SDK and a link to a page of our documentation with the customisation option for AccessCheckoutTextInput

### **WHY**

So that merchants understand the functionality and implementation process of the React Native SDK