### PR TITLE
Us1764780 amend README

### DIFF
--- a/access-checkout-react-native-sdk/README.md
+++ b/access-checkout-react-native-sdk/README.md
@@ -21,8 +21,8 @@ You can find the detailed documentation explaining how to integrate the SDK and 
 
 ## SAQ-A Compliance
 
-AccessCheckoutTextInput is the name of the new component created to provide SAQ-A compliance when using our React Native SDK.
-It has been designed so that it does not expose any methods or properties to retrieve the text entered by the end user to ensure our merchants applications are SAQ-A compliant.
+To support SAQ-A compliance when using our React Native SDK, we have created a new component called AccessCheckoutTextInput, created to provide SAQ-A compliance when using our React Native SDK.
+It has been designed so that it does not expose any methods or properties to retrieve the text entered by the end user to ensure our merchants applications do not have direct access to card details and are SAQ-A compliant.
 
 ## AccessCheckoutTextInput
 

--- a/access-checkout-react-native-sdk/README.md
+++ b/access-checkout-react-native-sdk/README.md
@@ -21,7 +21,7 @@ You can find the detailed documentation explaining how to integrate the SDK and 
 
 ## SAQ-A Compliance
 
-To support SAQ-A compliance when using our React Native SDK, we have created a new component called AccessCheckoutTextInput, created to provide SAQ-A compliance when using our React Native SDK.
+To support SAQ-A compliance when using our React Native SDK, we have created a new component called AccessCheckoutTextInput:
 It has been designed so that it does not expose any methods or properties to retrieve the text entered by the end user to ensure our merchants applications do not have direct access to card details and are SAQ-A compliant.
 
 ## AccessCheckoutTextInput

--- a/access-checkout-react-native-sdk/README.md
+++ b/access-checkout-react-native-sdk/README.md
@@ -26,7 +26,7 @@ It has been designed so that it does not expose any methods or properties to ret
 
 ## AccessCheckoutTextInput
 
-You can find detailed documentation about our new component [AccessCheckoutTextInput](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native/access-checkout-text-input) within the [React Native section](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native) of the [Access Worldpay Checkout documentation](https://developer.worldpay.com).
+You can find detailed documentation about our new component [AccessCheckoutTextInput](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native/optional-configuration) within the [React Native section](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native) of the [Access Worldpay Checkout documentation](https://developer.worldpay.com).
 
 ## How to install
 

--- a/access-checkout-react-native-sdk/README.md
+++ b/access-checkout-react-native-sdk/README.md
@@ -11,13 +11,22 @@ It is designed to simplify the integration of the following functionality in you
 
 ## Documentation
 
-You can find the detailed documentation explaining how to integrate the SDK and use a session to take a payment starting with the [React Native section](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native) of the [Access Worldpay documentation](https://developer.worldpay.com).
+You can find the detailed documentation explaining how to integrate the SDK and use a session to take a payment starting with the [React Native section](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native) of the [Access Worldpay Checkout documentation](https://developer.worldpay.com).
 
 ## Compatibility
 
 - all `react-native` versions >= `0.61.5`
 - all `react` versions >= `16.9.0`
 - `Cocoapods` only for iOS dependencies
+
+## SAQ-A Compliance
+
+AccessCheckoutTextInput is the name of the new component created to provide SAQ-A compliance when using our React Native SDK.
+It has been designed so that it does not expose any methods or properties to retrieve the text entered by the end user to ensure our merchants applications are SAQ-A compliant.
+
+## AccessCheckoutTextInput
+
+You can find detailed documentation about our new component [AccessCheckoutTextInput](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native/access-checkout-text-input) within the [React Native section](https://developer.worldpay.com/docs/access-worldpay/checkout/react-native) of the [Access Worldpay Checkout documentation](https://developer.worldpay.com).
 
 ## How to install
 


### PR DESCRIPTION
### **WHAT**
I want to read information in the README's of the React Native SDK Repository which is inline with Checkout implementation and functionality 

### **HOW**
README under the access-checkout-react-native-sdk folder contains details about the SAQ-A compliance feature of the SDK and a link to a page of our documentation with the customisation option for AccessCheckoutTextInput

### **WHY**
So that merchants understand the functionality and implementation process of the React Native SDK