### PR TITLE
NOTICKET: fix issue where app attempts to retrieve a file that does not exist for unknown card brands

### DIFF
--- a/demo-app/src/card-flow/CardFlow.tsx
+++ b/demo-app/src/card-flow/CardFlow.tsx
@@ -26,11 +26,8 @@ import CardFlowE2eStates from './CardFlow.e2e.states';
 import styles from './style.js';
 
 export default function CardFlow() {
-  const unknownBrandLogo =
-    'https://try.access.worldpay.com/access-checkout/assets/unknown.png';
-
   const [brand, setBrand] = useState<string>('');
-  const [brandLogo, setBrandLogo] = useState<string>(unknownBrandLogo);
+  const [brandLogo, setBrandLogo] = useState<string>('');
   const [panIsValid, setPanIsValid] = useState<boolean>(false);
   const [expiryIsValid, setExpiryIsValid] = useState<boolean>(false);
   const [cvcIsValid, setCvcIsValid] = useState<boolean>(false);
@@ -52,7 +49,7 @@ export default function CardFlow() {
     onCardBrandChanged(brand?: Brand): void {
       if (!brand) {
         setBrand('');
-        setBrandLogo(unknownBrandLogo);
+        setBrandLogo('');
         return;
       }
 

--- a/demo-app/src/common/CardBrandImage.tsx
+++ b/demo-app/src/common/CardBrandImage.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { StyleSheet, Image } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import UIComponentProps from './UIComponentProps';
 
 const styles = StyleSheet.create({
+  view: {
+    width: 80,
+  },
   logo: {
     borderRadius: 5,
     flex: 2,
@@ -19,15 +22,18 @@ interface CardBrandImageProps extends UIComponentProps {
 }
 
 const CardBrandImage = (props: CardBrandImageProps) => {
-  return (
-    <Image
-      testID={props.testID}
-      style={styles.logo}
-      source={{
-        uri: props.logo,
-      }}
-    />
-  );
+  let image;
+  if (props.logo) {
+    image = (
+      <Image
+        testID={props.testID}
+        style={styles.logo}
+        source={{ uri: props.logo }}
+      />
+    );
+  }
+
+  return <View style={styles.view}>{image}</View>;
 };
 
 export default CardBrandImage;


### PR DESCRIPTION
## What
- demo app has been changed to display no image when the card brand is not recognised

## Why
- the application was attempting to load a file at a URL that does not exist. That was provoking 404 errors in our logs and just making noise for no reasons