### PR TITLE
US2207298: add support for changing the placeholder colour

### DIFF
--- a/access-checkout-react-native-sdk/access-checkout-react-native-sdk.podspec
+++ b/access-checkout-react-native-sdk/access-checkout-react-native-sdk.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Worldpay/access-checkout-react-native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/AccessCheckoutReactNative/**/*.{h,m,mm,swift}"
-  s.dependency "AccessCheckoutSDK", "~> 3.0.0"
+  s.dependency "AccessCheckoutSDK", "~> 4.1"
   s.resource_bundles = { 'access-checkout-react-native-sdk' => [ 'ios/PrivacyInfo.xcprivacy' ] }
 
 if ENV['USE_FRAMEWORKS']

--- a/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManager.kt
+++ b/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManager.kt
@@ -10,7 +10,6 @@ import com.facebook.react.uimanager.ViewProps
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
 
-
 class AccessCheckoutTextInputManager :
     SimpleViewManager<AccessCheckoutEditText>() {
 
@@ -74,11 +73,11 @@ class AccessCheckoutTextInputManager :
 
         // Font Weight only supported in API >28
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && fontWeightProvidedAsUnit) {
-            val fontAsString = font.getString(ViewProps.FONT_WEIGHT)
+            val fontAsString:String? = font.getString(ViewProps.FONT_WEIGHT)
             // Note: This default should never happen as we use fontWeightProvidedAsUnit as a check
             // but to avoid a compilation false positive we default to 400 which should be the regular for fonts.
             // Also: Using font.getInt() seems to cause a casting issue where it casts tries to cast a String to a Double, which makes the app crash.
-            val fontWeightNumber = fontAsString?.toInt() ?: 400
+            val fontWeightNumber = if (fontAsString != null) Integer.parseInt(fontAsString) else 400
             customTypeface = Typeface.create(customTypeface, fontWeightNumber, italic)
         }
 
@@ -98,10 +97,14 @@ class AccessCheckoutTextInputManager :
         accessCheckoutEditText.setHint(placeholder)
     }
 
+    @ReactProp(name = "placeholderTextColor", customType = "Color")
+    fun setRTCPlaceholderTextColor(accessCheckoutEditText: AccessCheckoutEditText, placeholderTextColor: Int) {
+        accessCheckoutEditText.setHintTextColor(placeholderTextColor);
+    }
+
     @ReactProp(name = "editable")
     fun setRTCEditable(accessCheckoutEditText: AccessCheckoutEditText, editable: Boolean) {
         accessCheckoutEditText.isEnabled = editable
     }
 
 }
-

--- a/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManagerTest.kt
+++ b/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManagerTest.kt
@@ -3,6 +3,7 @@ package com.worldpay.access.checkout.reactnative.ui
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
+import androidx.core.graphics.toColorInt
 import androidx.test.core.app.ApplicationProvider
 import com.facebook.react.bridge.*
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
@@ -149,5 +150,12 @@ internal class AccessCheckoutTextInputManagerTest {
 
         val expectedTypeface =  Typeface.create("Rubik", Typeface.NORMAL);
         verify(accessCheckoutEditTextMock).typeface = Typeface.create(expectedTypeface, 100, true)
+    }
+
+    @Test
+    fun `setRTCPlaceholderTextColor() should change the hint text color on AccessEditText`() {
+        manager.setRTCPlaceholderTextColor(accessCheckoutEditTextMock, 123)
+
+        verify(accessCheckoutEditTextMock).setHintTextColor(123)
     }
 }

--- a/access-checkout-react-native-sdk/ios/AccessCheckoutReactNative/AccessCheckoutReactNative.swift
+++ b/access-checkout-react-native-sdk/ios/AccessCheckoutReactNative/AccessCheckoutReactNative.swift
@@ -32,7 +32,7 @@ class AccessCheckoutReactNative: RCTEventEmitter {
             if accessCheckoutClient == nil {
                 accessCheckoutClient = try! AccessCheckoutClientBuilder()
                     .accessBaseUrl(cfg.baseUrl)
-                    .merchantId(cfg.merchantId)
+                    .checkoutId(cfg.merchantId)
                     .build()
             }
             

--- a/access-checkout-react-native-sdk/ios/AccessCheckoutReactNative/AccessCheckoutTextInputManager.m
+++ b/access-checkout-react-native-sdk/ios/AccessCheckoutReactNative/AccessCheckoutTextInputManager.m
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTViewManager.h>
+#import <AccessCheckoutSDK/AccessCheckoutSDK-Swift.h>
 
 @interface RCT_EXTERN_MODULE(AccessCheckoutTextInputManager, RCTViewManager)
 
@@ -11,5 +12,13 @@ RCT_REMAP_VIEW_PROPERTY(editable, isEnabled, BOOL)
 
 RCT_REMAP_VIEW_PROPERTY(color, textColor, UIColor)
 RCT_REMAP_VIEW_PROPERTY(font, font, UIFont)
+
+RCT_CUSTOM_VIEW_PROPERTY(placeholderTextColor, UIColor, AccessCheckoutUITextField)
+{
+    UIColor *uiColor = [RCTConvert UIColor:json];
+    if (uiColor != nil) {
+        view.attributedPlaceholder = [[NSAttributedString alloc] initWithString:view.placeholder attributes:@{NSForegroundColorAttributeName: uiColor}];
+    }
+}
 
 @end

--- a/access-checkout-react-native-sdk/ios/Podfile
+++ b/access-checkout-react-native-sdk/ios/Podfile
@@ -24,7 +24,7 @@ target 'AccessCheckoutReactNative' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'AccessCheckoutSDK', '3.0.0'
+  pod 'AccessCheckoutSDK', '~> 4.1'
 
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202

--- a/access-checkout-react-native-sdk/ios/Podfile.lock
+++ b/access-checkout-react-native-sdk/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AccessCheckoutSDK (3.0.0)
+  - AccessCheckoutSDK (4.1.1)
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.11)
@@ -1066,7 +1066,7 @@ PODS:
   - Yoga (1.14.0)
 
 DEPENDENCIES:
-  - AccessCheckoutSDK (= 3.0.0)
+  - AccessCheckoutSDK (~> 4.1)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -1236,7 +1236,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/kylef/Mockingjay.git
 
 SPEC CHECKSUMS:
-  AccessCheckoutSDK: a3eaf9feb92b2d2c9e362c395f0c8d81acc895d3
+  AccessCheckoutSDK: 5110651cbd062aeef82216f33065b5fbb6cccdb6
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: b46891061bfe0a9b07f601813114c8653a72a45c
@@ -1245,52 +1245,52 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: d992945b77c506e5164e6a9a77510c9d57472c59
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  Mockingjay: 2f6c88dc1487535fd46876be59e4d3ce298a78eb
-  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
+  Mockingjay: 97656c6f59879923976a0a52ef09da45756cca82
+  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 415e56f7c33799a6483e41e4dce607f3daf1e69b
   RCTTypeSafety: e984a88e713281c2d8c2309a1a6d2775af0107ae
   React: ab885684e73c5f659bad63446a977312fd3d1ecb
   React-callinvoker: 50a2d1ce3594637c700401ba306373321231eb71
-  React-Codegen: 82347e020719c7de190ddadd16fb8f5bcf4a9a52
-  React-Core: d5166294382484f57e25dfde05ba00596703d51c
-  React-CoreModules: 459534f8112ee73e94f04f5e58276b3d236efd16
-  React-cxxreact: d5716540fd97df323792ef1d227f50515fb3e1a8
+  React-Codegen: 35331de15e1216a8f81a3134a0b459416fddef66
+  React-Core: 9d66a8a953d975aee4989abccf4602e7ba7c65fa
+  React-CoreModules: e93a24aaae933d496329112cec78b681c76cdc53
+  React-cxxreact: 8f6abe06e11f79f2292c7939dc6390027e53e5ba
   React-debug: 660486c6bbf3fd9a3d36082b6c3e2d247bc09b41
-  React-Fabric: 3412294ff4fad19c5946892a786d7804f7e76988
-  React-FabricImage: 8b3316ad5c87d9f2388911570126808abef45ad8
-  React-graphics: cf4ce028912bd9939b46f43924c5b7c85b5a7591
-  React-hermes: 59ff965e45955d66977a23d51fe9235b44a09bd4
-  React-ImageManager: 03a2aac0c6c83239a68fa1b72ba167697aca689d
-  React-jserrorhandler: 262542e2d31b6dcd9579669c76d42dfe270a8aa5
-  React-jsi: 36f85df7d83197707e9fd9320d857eac616e6df3
-  React-jsiexecutor: a68ea442fd94c7ecf5d9355bde2443f0241531d9
+  React-Fabric: 5345c138b3a3d7cd7ebd5ff0f7f92523f77ccbc9
+  React-FabricImage: 3be67bb7a2a1dd25b1cfec89484410bdeddb675c
+  React-graphics: 21b645518ccfbb0850d71b4305db3858ac0944ba
+  React-hermes: c2877efac91c02266c66cd62ccef3fa7c36d8604
+  React-ImageManager: 8e2d7bc1f7a936772f4d0ad242e504a87a88eb8e
+  React-jserrorhandler: 85774b25774fdba4eb88ba501b02893bc6850457
+  React-jsi: 5da729c3787b5d58b8612fcd4308290e88af9dde
+  React-jsiexecutor: 911f565c4dcb2faf750e274a18012c88355fc33c
   React-jsinspector: a98428936fb888cc15d857226a26d9ac0a668a0e
-  React-logger: 6e4873d1f9c54cca30f6c91a6617f8c91b75ba4c
-  React-Mapbuffer: f950f61557aecfb4beb33c26a7b709f4491cfbd7
+  React-logger: 6c1170f7bc315878ef4bd3b918e09130cf632798
+  React-Mapbuffer: 300b7684f71a676e9f2dbf6d67e14f39adfe84d3
   React-nativeconfig: 6178939b2ac9010dd2f9f994aab3ab11fa68fbf3
-  React-NativeModulesApple: eea6abc6e6ea549faa10d867e44b3eba2d8cec3d
+  React-NativeModulesApple: 802f2357d0af3e0eaf57db321987f6a425fd3c6d
   React-perflogger: 3887a05940ccd34a83457fd153fdeda509b31737
   React-RCTActionSheet: 2f42b4797374b53e93b65c79eaa8a0d292e255ac
-  React-RCTAnimation: 5639dcd418b798b28e9caacaed18ff5472454837
-  React-RCTAppDelegate: 37d3142bfa7cb9f2f8cd41feedc6b50c95986029
-  React-RCTBlob: e9f735bb085c6da208dd138bd4bfd294a52e3a86
-  React-RCTFabric: 1a7f59a4034e51c4852b7d01ab2832ab42a62f36
-  React-RCTImage: cc82df2b50bbdc1a0a0b19bf6fc16dd321eb8f0f
-  React-RCTLinking: 3d7900f52ecf03bb2522d7b94d8d16cce776294a
-  React-RCTNetwork: ac25c15ee52eb4aadb510afe68db0d1f949c45fa
-  React-RCTSettings: 013301fe7304ff06acca5287f6f754c9fa2b63b7
-  React-RCTText: ba6997c26241ea0b36ec8f98502a4ed45cab18e4
-  React-RCTVibration: b5ba13ed0909d2f2614ed99b067543e6ea0d7c37
-  React-rendererdebug: 50602bce0c403157f1ac87dce8600e63a3f7bce9
+  React-RCTAnimation: 8d855a38975b065bab2528ccf158734044bcec59
+  React-RCTAppDelegate: bddf79fb86d03810269d1af5d6ad06a654479a16
+  React-RCTBlob: f4bad11cecd4ed488dcbbda1581ff8fe92746107
+  React-RCTFabric: 6d8b3e82114a8c2db17f37c146554938c89f4600
+  React-RCTImage: 187d39d7f82dbddaee1c00fe5beb3fb4cd16eee2
+  React-RCTLinking: 22568a7c6d2ee51ef4d5c36e9e4d9720f74e9aed
+  React-RCTNetwork: 6453b643f665273e31fdfe21cfa5a32666d61685
+  React-RCTSettings: 237e7aa727543b5df2e0eecbfc49fc1bf21482b5
+  React-RCTText: 9a775859da5b6a1a2e4bebcd358909a77072f7c8
+  React-RCTVibration: 0167279571af233088b53ca3c67606b2a355a0f2
+  React-rendererdebug: 7ac55d2cacbfde959d81ce9dc5d262926d0081c6
   React-rncore: e7e1c1175d7e739acc80800d5ae343641f627488
   React-runtimeexecutor: 2fd27b921f664e66d903ee274dcda55cc0b2cb2e
-  React-runtimescheduler: f9d6540afe0a726320afe26cecf6189218b0b5a6
-  React-utils: d1465452d47b2600e7e00bbe75651bef04f24342
-  ReactCommon: 1102fc1d78fbfc56c57123e18d3acc14378f1403
+  React-runtimescheduler: 08a4e7fa9735811df202a7dd43703ad7dbd5eb3c
+  React-utils: 7ea0aecc0aec186197ba41491992c7d0d4d77660
+  ReactCommon: cd1a327b37af7f7c17fda8125faf3f7865320b05
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   URITemplate: 5f5a79f3e384884102c4e6b3325d159c20a8035a
   Yoga: d8b0f242670c8d28249d3aab276ca1a3b8db34f5
 
-PODFILE CHECKSUM: 3417106fa17d96eb032346f748de5b3615bc7ec1
+PODFILE CHECKSUM: 8fd50681b207e92fbafdef837dc1dcf7a3c6118a
 
 COCOAPODS: 1.16.2

--- a/access-checkout-react-native-sdk/src/ui/AccessCheckoutTextInput.tsx
+++ b/access-checkout-react-native-sdk/src/ui/AccessCheckoutTextInput.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type ColorValue, type StyleProp, StyleSheet, View, type ViewStyle } from 'react-native';
 import { RTCAccessCheckoutTextInput } from './RCTAccessCheckoutTextInput';
+import { processColor } from 'react-native';
 
 /**
  * Composes `AccessCheckoutTextInput`.
@@ -9,6 +10,7 @@ import { RTCAccessCheckoutTextInput } from './RCTAccessCheckoutTextInput';
  * - testID: string
  * - style: StyleProp<AccessCheckoutTextInputStyle>;
  * - placeholder: string
+ * - placeholderTextColor: ColorValue
  * - editable: boolean
  */
 export interface AccessCheckoutTextInputProps {
@@ -16,6 +18,7 @@ export interface AccessCheckoutTextInputProps {
   testID?: string;
   style?: StyleProp<AccessCheckoutTextInputStyle>;
   placeholder?: string;
+  placeholderTextColor?: ColorValue;
   editable?: boolean;
 }
 
@@ -51,7 +54,7 @@ export interface AccessCheckoutTextInputStyle extends ViewStyle {
 }
 
 export const AccessCheckoutTextInput: React.FC<AccessCheckoutTextInputProps> = (props) => {
-  const { nativeID, testID, style, placeholder, editable } = props;
+  const { nativeID, testID, style, placeholder, placeholderTextColor, editable } = props;
 
   const {
     color,
@@ -74,6 +77,7 @@ export const AccessCheckoutTextInput: React.FC<AccessCheckoutTextInputProps> = (
         testID={testID}
         style={[{ flex: 1 }]}
         placeholder={placeholder}
+        placeholderTextColor={processColor(placeholderTextColor)}
         font={{
           fontFamily,
           fontSize,

--- a/access-checkout-react-native-sdk/src/ui/RCTAccessCheckoutTextInput.tsx
+++ b/access-checkout-react-native-sdk/src/ui/RCTAccessCheckoutTextInput.tsx
@@ -1,4 +1,10 @@
-import { requireNativeComponent, type ColorValue, type StyleProp, type TextStyle } from 'react-native';
+import {
+  requireNativeComponent,
+  type ColorValue,
+  type StyleProp,
+  type TextStyle,
+  ProcessedColorValue,
+} from 'react-native';
 
 /**
  * Font Changes apply to placeholder text and input text
@@ -20,6 +26,7 @@ interface RTCAccessCheckoutTextInputProps {
   testID?: string;
   style?: StyleProp<TextStyle>;
   placeholder?: string;
+  placeholderTextColor?: ProcessedColorValue | null;
   font?: RTCAccessCheckoutTextInputFontProps;
   editable?: boolean;
   color?: ColorValue;

--- a/demo-app/ios/Podfile
+++ b/demo-app/ios/Podfile
@@ -19,6 +19,8 @@ end
 target 'AccessCheckoutReactNativeDemo' do
   use_frameworks! :linkage => :static
 
+  pod 'AccessCheckoutSDK', '~> 4.1'
+
   config = use_native_modules!
 
   use_react_native!(

--- a/demo-app/ios/Podfile.lock
+++ b/demo-app/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - access-checkout-react-native-sdk (3.0.0):
-    - AccessCheckoutSDK (~> 3.0.0)
+    - AccessCheckoutSDK (~> 4.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - AccessCheckoutSDK (3.0.0)
+  - AccessCheckoutSDK (4.1.1)
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.11)
@@ -1064,6 +1064,7 @@ PODS:
 
 DEPENDENCIES:
   - "access-checkout-react-native-sdk (from `../node_modules/@worldpay/access-worldpay-checkout-react-native-sdk`)"
+  - AccessCheckoutSDK (~> 4.1)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -1225,8 +1226,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  access-checkout-react-native-sdk: bcc77d87ff934fd2e1ecb729403b5a54c446bf0e
-  AccessCheckoutSDK: a3eaf9feb92b2d2c9e362c395f0c8d81acc895d3
+  access-checkout-react-native-sdk: 40bf53846be73447bf9444bc48d3d7e54d9f9c5c
+  AccessCheckoutSDK: 5110651cbd062aeef82216f33065b5fbb6cccdb6
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: b46891061bfe0a9b07f601813114c8653a72a45c
@@ -1235,50 +1236,50 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: d992945b77c506e5164e6a9a77510c9d57472c59
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
+  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 415e56f7c33799a6483e41e4dce607f3daf1e69b
   RCTTypeSafety: e984a88e713281c2d8c2309a1a6d2775af0107ae
   React: ab885684e73c5f659bad63446a977312fd3d1ecb
   React-callinvoker: 50a2d1ce3594637c700401ba306373321231eb71
-  React-Codegen: 82347e020719c7de190ddadd16fb8f5bcf4a9a52
-  React-Core: d5166294382484f57e25dfde05ba00596703d51c
-  React-CoreModules: 459534f8112ee73e94f04f5e58276b3d236efd16
-  React-cxxreact: d5716540fd97df323792ef1d227f50515fb3e1a8
+  React-Codegen: 35331de15e1216a8f81a3134a0b459416fddef66
+  React-Core: 9d66a8a953d975aee4989abccf4602e7ba7c65fa
+  React-CoreModules: e93a24aaae933d496329112cec78b681c76cdc53
+  React-cxxreact: 8f6abe06e11f79f2292c7939dc6390027e53e5ba
   React-debug: 660486c6bbf3fd9a3d36082b6c3e2d247bc09b41
-  React-Fabric: 3412294ff4fad19c5946892a786d7804f7e76988
-  React-FabricImage: 8b3316ad5c87d9f2388911570126808abef45ad8
-  React-graphics: cf4ce028912bd9939b46f43924c5b7c85b5a7591
-  React-hermes: 59ff965e45955d66977a23d51fe9235b44a09bd4
-  React-ImageManager: 03a2aac0c6c83239a68fa1b72ba167697aca689d
-  React-jserrorhandler: 262542e2d31b6dcd9579669c76d42dfe270a8aa5
-  React-jsi: 36f85df7d83197707e9fd9320d857eac616e6df3
-  React-jsiexecutor: a68ea442fd94c7ecf5d9355bde2443f0241531d9
+  React-Fabric: 5345c138b3a3d7cd7ebd5ff0f7f92523f77ccbc9
+  React-FabricImage: 3be67bb7a2a1dd25b1cfec89484410bdeddb675c
+  React-graphics: 21b645518ccfbb0850d71b4305db3858ac0944ba
+  React-hermes: c2877efac91c02266c66cd62ccef3fa7c36d8604
+  React-ImageManager: 8e2d7bc1f7a936772f4d0ad242e504a87a88eb8e
+  React-jserrorhandler: 85774b25774fdba4eb88ba501b02893bc6850457
+  React-jsi: 5da729c3787b5d58b8612fcd4308290e88af9dde
+  React-jsiexecutor: 911f565c4dcb2faf750e274a18012c88355fc33c
   React-jsinspector: a98428936fb888cc15d857226a26d9ac0a668a0e
-  React-logger: 6e4873d1f9c54cca30f6c91a6617f8c91b75ba4c
-  React-Mapbuffer: f950f61557aecfb4beb33c26a7b709f4491cfbd7
+  React-logger: 6c1170f7bc315878ef4bd3b918e09130cf632798
+  React-Mapbuffer: 300b7684f71a676e9f2dbf6d67e14f39adfe84d3
   React-nativeconfig: 6178939b2ac9010dd2f9f994aab3ab11fa68fbf3
-  React-NativeModulesApple: eea6abc6e6ea549faa10d867e44b3eba2d8cec3d
+  React-NativeModulesApple: 802f2357d0af3e0eaf57db321987f6a425fd3c6d
   React-perflogger: 3887a05940ccd34a83457fd153fdeda509b31737
   React-RCTActionSheet: 2f42b4797374b53e93b65c79eaa8a0d292e255ac
-  React-RCTAnimation: 5639dcd418b798b28e9caacaed18ff5472454837
-  React-RCTAppDelegate: 37d3142bfa7cb9f2f8cd41feedc6b50c95986029
-  React-RCTBlob: e9f735bb085c6da208dd138bd4bfd294a52e3a86
-  React-RCTFabric: 1a7f59a4034e51c4852b7d01ab2832ab42a62f36
-  React-RCTImage: cc82df2b50bbdc1a0a0b19bf6fc16dd321eb8f0f
-  React-RCTLinking: 3d7900f52ecf03bb2522d7b94d8d16cce776294a
-  React-RCTNetwork: ac25c15ee52eb4aadb510afe68db0d1f949c45fa
-  React-RCTSettings: 013301fe7304ff06acca5287f6f754c9fa2b63b7
-  React-RCTText: ba6997c26241ea0b36ec8f98502a4ed45cab18e4
-  React-RCTVibration: b5ba13ed0909d2f2614ed99b067543e6ea0d7c37
-  React-rendererdebug: 50602bce0c403157f1ac87dce8600e63a3f7bce9
+  React-RCTAnimation: 8d855a38975b065bab2528ccf158734044bcec59
+  React-RCTAppDelegate: bddf79fb86d03810269d1af5d6ad06a654479a16
+  React-RCTBlob: f4bad11cecd4ed488dcbbda1581ff8fe92746107
+  React-RCTFabric: 6d8b3e82114a8c2db17f37c146554938c89f4600
+  React-RCTImage: 187d39d7f82dbddaee1c00fe5beb3fb4cd16eee2
+  React-RCTLinking: 22568a7c6d2ee51ef4d5c36e9e4d9720f74e9aed
+  React-RCTNetwork: 6453b643f665273e31fdfe21cfa5a32666d61685
+  React-RCTSettings: 237e7aa727543b5df2e0eecbfc49fc1bf21482b5
+  React-RCTText: 9a775859da5b6a1a2e4bebcd358909a77072f7c8
+  React-RCTVibration: 0167279571af233088b53ca3c67606b2a355a0f2
+  React-rendererdebug: 7ac55d2cacbfde959d81ce9dc5d262926d0081c6
   React-rncore: e7e1c1175d7e739acc80800d5ae343641f627488
   React-runtimeexecutor: 2fd27b921f664e66d903ee274dcda55cc0b2cb2e
-  React-runtimescheduler: f9d6540afe0a726320afe26cecf6189218b0b5a6
-  React-utils: d1465452d47b2600e7e00bbe75651bef04f24342
-  ReactCommon: 1102fc1d78fbfc56c57123e18d3acc14378f1403
+  React-runtimescheduler: 08a4e7fa9735811df202a7dd43703ad7dbd5eb3c
+  React-utils: 7ea0aecc0aec186197ba41491992c7d0d4d77660
+  ReactCommon: cd1a327b37af7f7c17fda8125faf3f7865320b05
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: d8b0f242670c8d28249d3aab276ca1a3b8db34f5
 
-PODFILE CHECKSUM: 566d3e7598ed782387e85047135ffdbcf889ffbe
+PODFILE CHECKSUM: d1af720ffb2002680e43fcb9216e39eccdf43c3c
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
### What
- add support for customising placeholder text color using a new property named `placeholderTextColor`
- it supports [all colour notations supported in React Native](https://reactnative.dev/docs/colors)

### How
- add `placeholderTextColor` property to UI Components in React Native layer
  - `AccessCheckoutTextInput` expects a color in any of the notations supported by React Native and it transforms it using the `processColor()` function before passing it to `RCTAccessCheckoutTextInput`. This is to let React Native do the heavy lifting of transforming the colour in the expected format expected by Android & iOS
  - `RCTAccessCheckoutTextInput`expects the colour as an instance of `ProcessedColorValue`
- mapping in the native layers is done by leveraging mechanisms existing in the native technologies, i.e. without any custom code
  - in iOS, the transformation is done by using `RCTConverter which` converts what it receives into a `UIColor`. Also note that the property is declared in `RCT_CUSTOM_VIEW_PROPERTY` with a `UIColor` as a second argument; if using a different type such as String the transformation by the RCTConverter would not work
  - in Android, no transformation is required, the property received is already of type Int (type used for colours)

### Why
- this is to support use cases where dark mode is used