### PR TITLE
US2207298: tidy up Podfile.lock in demo-app

### DIFF
--- a/demo-app/ios/Podfile.lock
+++ b/demo-app/ios/Podfile.lock
@@ -1064,7 +1064,6 @@ PODS:
 
 DEPENDENCIES:
   - "access-checkout-react-native-sdk (from `../node_modules/@worldpay/access-worldpay-checkout-react-native-sdk`)"
-  - AccessCheckoutSDK (~> 4.1)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -1280,6 +1279,6 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: d8b0f242670c8d28249d3aab276ca1a3b8db34f5
 
-PODFILE CHECKSUM: d1af720ffb2002680e43fcb9216e39eccdf43c3c
+PODFILE CHECKSUM: 566d3e7598ed782387e85047135ffdbcf889ffbe
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
### What
- remove  iOS SDK dependency in Podfile.lock of demo app because it's not a direct dependency but a transitive one
