### PR TITLE
US2220378: bump version to 4.0.0

### DIFF
--- a/access-checkout-react-native-sdk/access-checkout-react-native-sdk.podspec
+++ b/access-checkout-react-native-sdk/access-checkout-react-native-sdk.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "access-checkout-react-native-sdk"
-  s.version      = "3.1.0"
+  s.version      = "4.0.0"
   s.summary      = package["description"]
   s.homepage     = package["repository"]["url"]
   s.license      = package["license"]

--- a/access-checkout-react-native-sdk/android/gradle.properties
+++ b/access-checkout-react-native-sdk/android/gradle.properties
@@ -1,4 +1,4 @@
-version=3.1.0
+version=4.0.0
 
 Worldpay_kotlinVersion=1.8.0
 Worldpay_minSdkVersion=24

--- a/access-checkout-react-native-sdk/package-lock.json
+++ b/access-checkout-react-native-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.20.0",

--- a/access-checkout-react-native-sdk/package.json
+++ b/access-checkout-react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Worldpay Access Checkout SDK for ReactNative",
   "repository": {
     "type": "git",

--- a/access-checkout-react-native-sdk/src/AccessCheckout.tsx
+++ b/access-checkout-react-native-sdk/src/AccessCheckout.tsx
@@ -13,7 +13,7 @@ interface InitialiseCvcOnlyValidationConfig {
   cvcId: string;
 }
 export default class AccessCheckout {
-  private readonly ReactNativeSdkVersion = '3.1.0';
+  private readonly ReactNativeSdkVersion = '4.0.0';
   static readonly CardValidationEventType = 'AccessCheckoutCardValidationEvent';
   static readonly CvcOnlyValidationEventType = 'AccessCheckoutCvcOnlyValidationEvent';
 

--- a/demo-app/ios/Podfile.lock
+++ b/demo-app/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - access-checkout-react-native-sdk (3.1.0):
+  - access-checkout-react-native-sdk (4.0.0):
     - AccessCheckoutSDK (~> 4.1)
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1225,7 +1225,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  access-checkout-react-native-sdk: 6e603afbedfdcec0bf26f793a129290c76783784
+  access-checkout-react-native-sdk: eec4ec0091e9ce0748927b1b7d2a230e9d5ec79f
   AccessCheckoutSDK: 5110651cbd062aeef82216f33065b5fbb6cccdb6
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -39,7 +39,7 @@
     },
     "../access-checkout-react-native-sdk": {
       "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.20.0",


### PR DESCRIPTION
### What
- bump version to 4.0.0

### Why
- our latest change is a breaking since we only support RN versions that support auto linking