### PR TITLE
US2240408: update min version(s) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 ## React & React Native Compatibility
 
 Our SDK is compatible with:
-- `React Native 0.70.0` and above 
-- `React 18.1.0` and above 
+- `React Native 0.76.0` and above
+- `React 18.3.0` and above
+- `Android API level 24 (Android 7)` and above
 
 ## Getting Started
 

--- a/access-checkout-react-native-sdk/README.md
+++ b/access-checkout-react-native-sdk/README.md
@@ -16,8 +16,9 @@ You can find the detailed documentation explaining how to integrate the SDK and 
 
 ## Compatibility
 
-- `React Native 0.70.0` and above
-- `React 18.1.0` and above
+- `React Native 0.76.0` and above
+- `React 18.3.0` and above
+- `Android API level 24 (Android 7)` and above
 - `Cocoapods` only for iOS dependencies
 
 ## SAQ-A Compliance


### PR DESCRIPTION
### What
update in README
- min version of RN to 0.76
- React 18.3 (see [react native 0.76 package.json](https://github.com/facebook/react-native/blob/v0.76.0/package.json))
- Android 24

### Why
- Android versions prior to 24 potentially fail SSL handshakes due to Certificate Authorities being different on different devices. This issue has been solved with Android 24 which introduces a fixed set of CAs independent of devices. The Worldpay Android SDK used by this React Native SDK mandates Android 24 for this reason.