### PR TITLE
DE658120: Updating iOS native dependency to 4.1.2; bump RN SDK version to 4.0.2

### DIFF
--- a/access-checkout-react-native-sdk/access-checkout-react-native-sdk.podspec
+++ b/access-checkout-react-native-sdk/access-checkout-react-native-sdk.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
   s.name         = "access-checkout-react-native-sdk"
-  s.version      = "4.0.1"
+  s.version      = "4.0.2"
   s.summary      = package["description"]
   s.homepage     = package["repository"]["url"]
   s.license      = package["license"]

--- a/access-checkout-react-native-sdk/android/gradle.properties
+++ b/access-checkout-react-native-sdk/android/gradle.properties
@@ -1,4 +1,4 @@
-version=4.0.1
+version=4.0.2
 
 Worldpay_kotlinVersion=1.8.0
 Worldpay_minSdkVersion=24

--- a/access-checkout-react-native-sdk/ios/Podfile.lock
+++ b/access-checkout-react-native-sdk/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AccessCheckoutSDK (4.1.1)
+  - AccessCheckoutSDK (4.1.2)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
@@ -1786,7 +1786,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/kylef/Mockingjay.git
 
 SPEC CHECKSUMS:
-  AccessCheckoutSDK: 5110651cbd062aeef82216f33065b5fbb6cccdb6
+  AccessCheckoutSDK: d2a5cd9cc570bd35e1d908edd8c9b14995709bf7
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
@@ -1857,4 +1857,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 96508667fd69dfac622aa6365b85abe309a1d20d
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/access-checkout-react-native-sdk/package-lock.json
+++ b/access-checkout-react-native-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/access-checkout-react-native-sdk/package.json
+++ b/access-checkout-react-native-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Worldpay Access Checkout SDK for ReactNative",
   "repository": {
     "type": "git",

--- a/access-checkout-react-native-sdk/src/AccessCheckout.tsx
+++ b/access-checkout-react-native-sdk/src/AccessCheckout.tsx
@@ -13,7 +13,7 @@ interface InitialiseCvcOnlyValidationConfig {
   cvcId: string;
 }
 export default class AccessCheckout {
-  private readonly ReactNativeSdkVersion = '4.0.1';
+  private readonly ReactNativeSdkVersion = '4.0.2';
   static readonly CardValidationEventType = 'AccessCheckoutCardValidationEvent';
   static readonly CvcOnlyValidationEventType = 'AccessCheckoutCvcOnlyValidationEvent';
 

--- a/demo-app/ios/Podfile.lock
+++ b/demo-app/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - access-checkout-react-native-sdk (4.0.1):
+  - access-checkout-react-native-sdk (4.0.2):
     - AccessCheckoutSDK (~> 4.1)
     - DoubleConversion
     - glog
@@ -21,7 +21,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - AccessCheckoutSDK (4.1.1)
+  - AccessCheckoutSDK (4.1.2)
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
@@ -1792,8 +1792,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  access-checkout-react-native-sdk: f1193372520f7b8c6a5f5d7310649db88ba2a415
-  AccessCheckoutSDK: 5110651cbd062aeef82216f33065b5fbb6cccdb6
+  access-checkout-react-native-sdk: a6b6ddac9464f73fd8ae5553905bedc2837f6097
+  AccessCheckoutSDK: d2a5cd9cc570bd35e1d908edd8c9b14995709bf7
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
@@ -1862,4 +1862,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 287792d66305602048e30aa6192f678f0eac02aa
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -46,7 +46,7 @@
     },
     "../access-checkout-react-native-sdk": {
       "name": "@worldpay/access-worldpay-checkout-react-native-sdk",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.25.2",


### PR DESCRIPTION
DE658120: Updating iOS native dependency to 4.1.2; bump RN SDK version to 4.0.2