### PR TITLE
feat: add support in Android to dismiss keyboard when tapping outside of AccessCheckoutTextInput

### DIFF
--- a/access-checkout-react-native-sdk/android/build.gradle
+++ b/access-checkout-react-native-sdk/android/build.gradle
@@ -121,6 +121,8 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.robolectric:robolectric:4.10.3'
     testImplementation 'org.mockito:mockito-core:5.16.1'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
 
 
     androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core"

--- a/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManager.kt
+++ b/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManager.kt
@@ -1,7 +1,10 @@
 package com.worldpay.access.checkout.reactnative.ui
 
+import android.content.Context
 import android.graphics.Typeface
 import android.os.Build
+import android.view.inputmethod.InputMethodManager
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -16,6 +19,50 @@ class AccessCheckoutTextInputManager :
 
     companion object {
         const val REACT_CLASS = "AccessCheckoutTextInput"
+        const val COMMAND_FOCUS = 1
+        const val COMMAND_BLUR = 2
+    }
+
+    override fun getCommandsMap(): Map<String, Int> {
+        return mapOf(
+            "focus" to COMMAND_FOCUS,
+            "blur" to COMMAND_BLUR
+        )
+    }
+
+    // Classic architecture uses integer command IDs from UIManager.getViewManagerConfig(...).Commands
+    @Deprecated("Deprecated")
+    override fun receiveCommand(view: AccessCheckoutEditText, commandId: Int, args: ReadableArray?) {
+        when (commandId) {
+            COMMAND_FOCUS -> focusView(view)
+            COMMAND_BLUR -> blurView(view)
+        }
+    }
+
+    // Keep string commands for compatibility with call sites that dispatch by name
+    override fun receiveCommand(view: AccessCheckoutEditText, commandId: String, args: ReadableArray?) {
+        when (commandId) {
+            "focus" -> focusView(view)
+            "blur" -> blurView(view)
+        }
+    }
+
+    private fun focusView(view: AccessCheckoutEditText) {
+        view.requestFocus()
+        val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+    }
+
+    private fun blurView(view: AccessCheckoutEditText) {
+        view.clearFocus()
+        val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> {
+        return mapOf(
+            "topFocusChange" to mapOf("registrationName" to "onFocusChange")
+        )
     }
 
     override fun createViewInstance(context: ThemedReactContext): AccessCheckoutEditText {
@@ -26,6 +73,7 @@ class AccessCheckoutTextInputManager :
         accessCheckoutEditText.background = null
         accessCheckoutEditText.textSize = 14f
         accessCheckoutEditText.setPadding(0, 0, 0, 0)
+        accessCheckoutEditText.onFocusChangeListener = CheckoutFocusChangeListener()
 
         return accessCheckoutEditText
     }

--- a/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/CheckoutFocusChangeListener.kt
+++ b/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/CheckoutFocusChangeListener.kt
@@ -1,0 +1,17 @@
+package com.worldpay.access.checkout.reactnative.ui
+
+import android.view.View
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+
+
+class CheckoutFocusChangeListener : View.OnFocusChangeListener {
+    override fun onFocusChange(view: View?, isFocused: Boolean) {
+        val targetView = view ?: return
+        val reactContext = targetView.context as? ReactContext ?: return
+
+        val surfaceId = UIManagerHelper.getSurfaceId(targetView.context)
+        UIManagerHelper.getEventDispatcherForReactTag(reactContext, targetView.id)
+            ?.dispatchEvent(FocusChangeEvent(surfaceId, targetView.id, isFocused))
+    }
+}

--- a/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/FocusChangeEvent.kt
+++ b/access-checkout-react-native-sdk/android/src/main/java/com/worldpay/access/checkout/reactnative/ui/FocusChangeEvent.kt
@@ -1,0 +1,21 @@
+package com.worldpay.access.checkout.reactnative.ui
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class FocusChangeEvent(surfaceId: Int, viewTag: Int, val isFocused: Boolean) : Event<FocusChangeEvent>() {
+    init {
+        super.init(surfaceId, viewTag)
+    }
+
+    public override fun getEventData(): WritableMap? {
+        val event = Arguments.createMap()
+        event.putBoolean("isFocused", isFocused)
+        return event
+    }
+
+    override fun getEventName(): String {
+        return "topFocusChange"
+    }
+}

--- a/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManagerTest.kt
+++ b/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/ui/AccessCheckoutTextInputManagerTest.kt
@@ -1,10 +1,7 @@
 package com.worldpay.access.checkout.reactnative.ui
 
-import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
-import androidx.core.graphics.toColorInt
-import androidx.test.core.app.ApplicationProvider
 import com.facebook.react.bridge.*
 import com.worldpay.access.checkout.ui.AccessCheckoutEditText
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
@@ -157,5 +154,24 @@ internal class AccessCheckoutTextInputManagerTest {
         manager.setRTCPlaceholderTextColor(accessCheckoutEditTextMock, 123)
 
         verify(accessCheckoutEditTextMock).setHintTextColor(123)
+    }
+
+    @Test
+    fun `getCommandsMap() should return a map containing focus and blur commands`() {
+        val commandsMap = manager.commandsMap
+
+        assertThat(commandsMap.size).isEqualTo(2)
+        assertThat(commandsMap["focus"]).isEqualTo(AccessCheckoutTextInputManager.COMMAND_FOCUS)
+        assertThat(commandsMap["blur"]).isEqualTo(AccessCheckoutTextInputManager.COMMAND_BLUR)
+    }
+
+    @Test
+    fun `getExportedCustomDirectEventTypeConstants() should return a map mapping the internal topFocusChange event to an onFocusChange event`() {
+        val eventsMap:Map<String, Any?> = manager.exportedCustomDirectEventTypeConstants
+        assertThat(eventsMap.size).isEqualTo(1)
+
+        val topFocusChangeEventMap = eventsMap["topFocusChange"] as Map<String, String>
+        assertThat(topFocusChangeEventMap.size).isEqualTo(1)
+        assertThat(topFocusChangeEventMap["registrationName"]).isEqualTo("onFocusChange")
     }
 }

--- a/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/ui/CheckoutFocusChangeListenerTest.kt
+++ b/access-checkout-react-native-sdk/android/src/test/java/com/worldpay/access/checkout/reactnative/ui/CheckoutFocusChangeListenerTest.kt
@@ -1,0 +1,73 @@
+package com.worldpay.access.checkout.reactnative.ui
+
+import android.view.View
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.EventDispatcher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutFocusChangeListenerTest {
+
+    private val listener = CheckoutFocusChangeListener()
+
+    @Test
+    fun `onFocusChange() should dispatch FocusChangeEvent with isFocused=true when view gains focus`() {
+        val reactContextMock = mock(ReactContext::class.java)
+        val viewMock = mock(View::class.java)
+        val eventDispatcherMock = mock(EventDispatcher::class.java)
+
+        `when`(viewMock.context).thenReturn(reactContextMock)
+        `when`(viewMock.id).thenReturn(42)
+
+        mockStatic(UIManagerHelper::class.java).use { uiManagerMock ->
+            uiManagerMock.`when`<Int> { UIManagerHelper.getSurfaceId(reactContextMock) }.thenReturn(1)
+            uiManagerMock.`when`<EventDispatcher?> {
+                UIManagerHelper.getEventDispatcherForReactTag(reactContextMock, 42)
+            }.thenReturn(eventDispatcherMock)
+
+            listener.onFocusChange(viewMock, true)
+
+            val captor = ArgumentCaptor.forClass(FocusChangeEvent::class.java)
+            verify(eventDispatcherMock).dispatchEvent(captor.capture())
+
+            val event = captor.value
+            assertThat(event.isFocused).isTrue()
+            assertThat(event.eventName).isEqualTo("topFocusChange")
+        }
+    }
+
+    @Test
+    fun `onFocusChange() should dispatch FocusChangeEvent with isFocused=false when view loses focus`() {
+        val reactContextMock = mock(ReactContext::class.java)
+        val viewMock = mock(View::class.java)
+        val eventDispatcherMock = mock(EventDispatcher::class.java)
+
+        `when`(viewMock.context).thenReturn(reactContextMock)
+        `when`(viewMock.id).thenReturn(42)
+
+        mockStatic(UIManagerHelper::class.java).use { uiManagerMock ->
+            uiManagerMock.`when`<Int> { UIManagerHelper.getSurfaceId(reactContextMock) }.thenReturn(1)
+            uiManagerMock.`when`<EventDispatcher?> {
+                UIManagerHelper.getEventDispatcherForReactTag(reactContextMock, 42)
+            }.thenReturn(eventDispatcherMock)
+
+            listener.onFocusChange(viewMock, false)
+
+            val captor = ArgumentCaptor.forClass(FocusChangeEvent::class.java)
+            verify(eventDispatcherMock).dispatchEvent(captor.capture())
+
+            val event = captor.value
+            assertThat(event.isFocused).isFalse()
+            assertThat(event.eventName).isEqualTo("topFocusChange")
+        }
+    }
+}

--- a/access-checkout-react-native-sdk/src/ui/AccessCheckoutTextInput.tsx
+++ b/access-checkout-react-native-sdk/src/ui/AccessCheckoutTextInput.tsx
@@ -114,11 +114,11 @@ export const AccessCheckoutTextInput: React.FC<AccessCheckoutTextInputProps> = (
     }
 
     if (event.nativeEvent.isFocused) {
-      TextInput.State.focusTextInput(ref.current);
+      TextInputState.focusInput(ref.current);
     } else {
       // Instructs React Native to forcibly remove the focus from our component
       // This in return sends a command to the underlying Android/iOS component
-      TextInput.State.blurTextInput(ref.current);
+      TextInputState.blurInput(ref.current);
     }
   };
 

--- a/demo-app/e2e/focus.e2e.js
+++ b/demo-app/e2e/focus.e2e.js
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { device, expect } = require('detox');
+const { CardFlowPO } = require('./page-objects/CardFlowPO');
+
+describe('Card flow', () => {
+  const view = new CardFlowPO();
+  const pan = view.pan;
+
+  beforeAll(async () => {
+    await device.launchApp();
+  });
+
+  beforeEach(async () => {
+    await device.reloadReactNative();
+  });
+
+  describe('when tapping outside of a card field', () => {
+    it('focus should be removed from that field', async () => {
+      await pan.tap();
+      await expect(pan.component()).toBeFocused();
+
+      await pan.clickOutside();
+
+      await expect(pan.component()).not.toBeFocused();
+    });
+  });
+});

--- a/demo-app/e2e/page-objects/AccessCheckoutTextInputPO.js
+++ b/demo-app/e2e/page-objects/AccessCheckoutTextInputPO.js
@@ -25,6 +25,10 @@ class AccessCheckoutTextInputPO extends UIComponentPO {
     const attributes = await this.getAttributes();
     return attributes.text;
   }
+
+  async clickOutside(x = 0, y = 200) {
+    await this.component().tap({ x: x, y: y });
+  }
 }
 
 module.exports = { AccessCheckoutTextInputPO };

--- a/demo-app/e2e/page-objects/AccessCheckoutTextInputPO.js
+++ b/demo-app/e2e/page-objects/AccessCheckoutTextInputPO.js
@@ -26,8 +26,8 @@ class AccessCheckoutTextInputPO extends UIComponentPO {
     return attributes.text;
   }
 
-  async clickOutside(x = 0, y = 200) {
-    await this.component().tap({ x: x, y: y });
+  async clickOutside(x = 10, y = 200) {
+    await element(by.id('root')).tap({ x: x, y: y });
   }
 }
 

--- a/demo-app/src/App.tsx
+++ b/demo-app/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
   const currentScreen = screen === screens.card ? <CardFlow /> : <CvcOnly />;
 
   return (
-    <VView style={styles.app}>
+    <VView style={styles.app} testID="root">
       <VView style={styles.main}>{currentScreen}</VView>
       <HView style={styles.nav}>
         <NavItem

--- a/demo-app/src/card-flow/CardFlow.tsx
+++ b/demo-app/src/card-flow/CardFlow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text } from 'react-native';
+import { Button, Keyboard, ScrollView, Text, TextInput } from 'react-native';
 import {
   Brand,
   CARD,
@@ -178,59 +178,66 @@ export default function CardFlow() {
   }
 
   return (
-    <VView style={styles.cardFlow} onLayout={onLayout}>
-      <Spinner testID="spinner" show={showSpinner} />
-      {errorComponent}
-      <HView>
-        <PanField
-          testID="panInput"
-          isValid={panIsValid}
-          isEditable={isEditable}
-        />
-        <CardBrandImage testID="cardBrandImage" logo={brandLogo} />
-      </HView>
-      <HView>
-        <ExpiryDateField
-          testID="expiryDateInput"
-          isValid={expiryIsValid}
-          isEditable={isEditable}
-        />
-        <CvcField
-          testID="cvcInput"
-          isValid={cvcIsValid}
-          isEditable={isEditable}
-        />
-      </HView>
-      <HView>
-        <HView style={{ marginTop: '2%', marginRight: '2%', marginLeft: '3%' }}>
-          <Text>Generate VT session + CVC session</Text>
+    <ScrollView
+      keyboardDismissMode={'on-drag'}
+      keyboardShouldPersistTaps="never"
+    >
+      <VView style={styles.cardFlow} onLayout={onLayout}>
+        <Spinner testID="spinner" show={showSpinner} />
+        {errorComponent}
+        <HView>
+          <PanField
+            testID="panInput"
+            isValid={panIsValid}
+            isEditable={isEditable}
+          />
+          <CardBrandImage testID="cardBrandImage" logo={brandLogo} />
         </HView>
-        <Toggle
-          testID="cardAndCvcSessionsToggle"
-          value={generateCardAndCvcSessions}
-          onChange={setGenerateCardAndCvcSessions}
-        />
-      </HView>
-      <VView style={{ marginTop: '8%' }}>
-        <SubmitButton
-          testID="submitButton"
-          onPress={createSession}
-          enabled={submitBtnEnabled}
+        <HView>
+          <ExpiryDateField
+            testID="expiryDateInput"
+            isValid={expiryIsValid}
+            isEditable={isEditable}
+          />
+          <CvcField
+            testID="cvcInput"
+            isValid={cvcIsValid}
+            isEditable={isEditable}
+          />
+        </HView>
+        <HView>
+          <HView
+            style={{ marginTop: '2%', marginRight: '2%', marginLeft: '3%' }}
+          >
+            <Text>Generate VT session + CVC session</Text>
+          </HView>
+          <Toggle
+            testID="cardAndCvcSessionsToggle"
+            value={generateCardAndCvcSessions}
+            onChange={setGenerateCardAndCvcSessions}
+          />
+        </HView>
+        <VView style={{ marginTop: '8%' }}>
+          <SubmitButton
+            testID="submitButton"
+            onPress={createSession}
+            enabled={submitBtnEnabled}
+          />
+        </VView>
+        <VView style={{ marginTop: '8%', marginLeft: '4%' }}>
+          <Text style={{ fontWeight: 'bold' }}>Sessions</Text>
+          {cardSessionComponent}
+          {cvcSessionComponent}
+        </VView>
+        <CardFlowE2eStates
+          testID="cardFlowE2eStates"
+          panIsValid={panIsValid}
+          expiryDateIsValid={expiryIsValid}
+          cvcIsValid={cvcIsValid}
+          submitButtonEnabled={submitBtnEnabled}
+          cardBrand={brand}
         />
       </VView>
-      <VView style={{ marginTop: '8%', marginLeft: '4%' }}>
-        <Text style={{ fontWeight: 'bold' }}>Sessions</Text>
-        {cardSessionComponent}
-        {cvcSessionComponent}
-      </VView>
-      <CardFlowE2eStates
-        testID="cardFlowE2eStates"
-        panIsValid={panIsValid}
-        expiryDateIsValid={expiryIsValid}
-        cvcIsValid={cvcIsValid}
-        submitButtonEnabled={submitBtnEnabled}
-        cardBrand={brand}
-      />
-    </VView>
+    </ScrollView>
   );
 }

--- a/demo-app/src/card-flow/CardFlow.tsx
+++ b/demo-app/src/card-flow/CardFlow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Keyboard, ScrollView, Text, TextInput } from 'react-native';
+import { ScrollView, Text } from 'react-native';
 import {
   Brand,
   CARD,

--- a/demo-app/src/card-flow/CardFlow.tsx
+++ b/demo-app/src/card-flow/CardFlow.tsx
@@ -180,7 +180,7 @@ export default function CardFlow() {
   return (
     <ScrollView
       keyboardDismissMode={'on-drag'}
-      keyboardShouldPersistTaps="never"
+      keyboardShouldPersistTaps="handled"
     >
       <VView style={styles.cardFlow} onLayout={onLayout}>
         <Spinner testID="spinner" show={showSpinner} />

--- a/demo-app/src/common/VView.tsx
+++ b/demo-app/src/common/VView.tsx
@@ -7,7 +7,7 @@ export default class VView extends Component<ViewProps> {
   }
 
   render() {
-    const { children, style, ...rest } = this.props;
+    const { children, style, testID, ...rest } = this.props;
 
     const styles: ViewStyle = {};
     styles.flexDirection = 'column';
@@ -16,7 +16,7 @@ export default class VView extends Component<ViewProps> {
     Object.assign(styles, style);
 
     return (
-      <View style={styles} {...rest}>
+      <View style={styles} testID={testID} {...rest}>
         {children}
       </View>
     );

--- a/demo-app/src/cvc-flow/CvcFlow.tsx
+++ b/demo-app/src/cvc-flow/CvcFlow.tsx
@@ -107,7 +107,7 @@ export default function CvcFlow() {
   return (
     <ScrollView
       keyboardDismissMode={'on-drag'}
-      keyboardShouldPersistTaps="never"
+      keyboardShouldPersistTaps="handled"
     >
       <VView style={styles.cardFlow} onLayout={onLayout}>
         <Spinner testID="spinner" show={showSpinner} />

--- a/demo-app/src/cvc-flow/CvcFlow.tsx
+++ b/demo-app/src/cvc-flow/CvcFlow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text } from 'react-native';
+import { ScrollView, Text } from 'react-native';
 import {
   CVC,
   CvcOnlyValidationEventListener,
@@ -105,32 +105,37 @@ export default function CvcFlow() {
   }
 
   return (
-    <VView style={styles.cardFlow} onLayout={onLayout}>
-      <Spinner testID="spinner" show={showSpinner} />
-      {errorComponent}
-      <HView>
-        <CvcField
-          testID="cvcInput"
-          isEditable={isEditable}
-          isValid={cvcIsValid}
-        />
-      </HView>
-      <VView style={{ marginTop: '8%' }}>
-        <SubmitButton
-          testID="submitButton"
-          onPress={createSession}
-          enabled={submitBtnEnabled}
+    <ScrollView
+      keyboardDismissMode={'on-drag'}
+      keyboardShouldPersistTaps="never"
+    >
+      <VView style={styles.cardFlow} onLayout={onLayout}>
+        <Spinner testID="spinner" show={showSpinner} />
+        {errorComponent}
+        <HView>
+          <CvcField
+            testID="cvcInput"
+            isEditable={isEditable}
+            isValid={cvcIsValid}
+          />
+        </HView>
+        <VView style={{ marginTop: '8%' }}>
+          <SubmitButton
+            testID="submitButton"
+            onPress={createSession}
+            enabled={submitBtnEnabled}
+          />
+        </VView>
+        <VView style={{ marginTop: '8%', marginLeft: '4%' }}>
+          <Text style={{ fontWeight: 'bold' }}>Sessions</Text>
+          {cvcSessionComponent}
+        </VView>
+        <CvcOnlyFlowE2eStates
+          testID="cvcOnlyFlowE2eStates"
+          cvcIsValid={cvcIsValid}
+          submitButtonEnabled={submitBtnEnabled}
         />
       </VView>
-      <VView style={{ marginTop: '8%', marginLeft: '4%' }}>
-        <Text style={{ fontWeight: 'bold' }}>Sessions</Text>
-        {cvcSessionComponent}
-      </VView>
-      <CvcOnlyFlowE2eStates
-        testID="cvcOnlyFlowE2eStates"
-        cvcIsValid={cvcIsValid}
-        submitButtonEnabled={submitBtnEnabled}
-      />
-    </VView>
+    </ScrollView>
   );
 }


### PR DESCRIPTION
### What
- Add support in Android bridge and `AccessCheckoutTextInput` to get keyboard dismissed when tapping outside of `AccessCheckoutTextInput` when component is in a ScrollView

### How
- the Android bridge `AccessCheckoutTextInputManager`  has been changed to handle focus and blur React Native commands. The handle for these commands respectively make the component become display or hide the keyboard
- the bridge also emits events when focus is acquired or lost so the React Native layer can react to it accordingly by calling TextInputState.focusInput() / blurInput()

### Why
- this is to support a functionality for merchants to hide the keyboard in their app so UX is better for their shoppers