### PR TITLE
Update Podfile to allow relative path to be recognised

### DIFF
--- a/access-checkout-react-native-sdk/ios/Podfile
+++ b/access-checkout-react-native-sdk/ios/Podfile
@@ -50,7 +50,7 @@ post_install do |installer|
   react_native_post_install(
     installer,
     # Use the config from the first target - both point to the same RN path
-    Pod::Config.instance.installation_root + '/../node_modules/react-native',
+    File.expand_path('../node_modules/react-native', __dir__),
     :mac_catalyst_enabled => false
   )
 


### PR DESCRIPTION
# What
Currently when trying to build the SDK for iOS against 0.86.0 it fails to build due to Ruby identifying the directory as an absolute path instead of a relative path
# How
Modify directory path to be relative for Ruby to build against 0.86.0

# Test
Check `bundle exec pod install` or `pod install` can succeed under the SDK directory for RN versions 0.83 and 0.86